### PR TITLE
CI: test that runs pdf pack examples in CI

### DIFF
--- a/.github/workflows/test-pdf-pack.yml
+++ b/.github/workflows/test-pdf-pack.yml
@@ -1,0 +1,61 @@
+name: Test PDF Pack Scripts
+
+on:
+  push:
+    branches: main
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  test-conda:
+    name: conda-${{ matrix.python-version }}-${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: [3.11, 3.12, 3.13] # requires manual update
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up conda
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+          channels: conda-forge
+      - name: Install diffpy.cmi
+        run: |
+          conda install -y diffpy.cmi
+      - name: Run diffpy.cmi scripts from docs/examples
+        shell: bash
+        run: |
+          set -e
+          export MPLBACKEND=Agg
+          for script in docs/examples/ch*/solutions/diffpy-cmi/*.py; do
+            python "$script"
+          done
+
+  test-pip:
+    name: pip-${{ matrix.python-version }}-${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: [3.11, 3.12, 3.13] # requires manual update
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install diffpy.cmi (pip)
+        run: |
+          python -m pip install --upgrade pip
+          pip install diffpy.cmi
+      - name: Run diffpy.cmi scripts from docs/examples
+        shell: bash
+        run: |
+          set -e
+          export MPLBACKEND=Agg
+          for script in docs/examples/ch*/solutions/diffpy-cmi/*.py; do
+            python "$script"
+          done

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,11 @@ __pycache__/
 # C extensions
 *.so
 
+# ignore any data saved by the diffpy.cmi examples
+docs/examples/ch*/solutions/diffpy-cmi/fig/*
+docs/examples/ch*/solutions/diffpy-cmi/fit/*
+docs/examples/ch*/solutions/diffpy-cmi/res/*
+
 # Distribution / packaging
 .Python
 env/

--- a/docs/examples/ch03NiModelling/solutions/diffpy-cmi/fitBulkNi.py
+++ b/docs/examples/ch03NiModelling/solutions/diffpy-cmi/fitBulkNi.py
@@ -70,7 +70,7 @@ QBROAD_I = 0.02
 
 # If we want to run using multiprocessors, we can switch this to 'True'.
 # This requires that the 'psutil' python package installed.
-RUN_PARALLEL = True
+RUN_PARALLEL = False
 
 
 # Functions that will carry out the refinement ##################

--- a/docs/examples/ch11ClusterXYZ/solutions/diffpy-cmi/fitCdSeNP.py
+++ b/docs/examples/ch11ClusterXYZ/solutions/diffpy-cmi/fitCdSeNP.py
@@ -199,9 +199,6 @@ def plot_results(recipe, figname):
     diff = g - gcalc + diffzero
 
     mpl.rcParams.update(mpl.rcParamsDefault)
-    plt.style.use(
-        str(PWD.parent.parent.parent / "utils" / "billinge.mplstyle")
-    )
 
     fig, ax1 = plt.subplots(1, 1)
 

--- a/news/test-tutorial-CI.rst
+++ b/news/test-tutorial-CI.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Add CI for testing examples of the PDF pack.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
closes #8 

This is my first time writing CI from scratch so please review carefully. Basically this CI should run all the scripts under `docs/examples` and should fail if the examples give an error. This way of testing can be refined but I think the concept should be okay for this release.

I tested how this operates functionally with the following shell script. I also set the mpl backend so it can run headless, since the example scripts show plots by default. 

```
#!/usr/bin/env bash
set -eu

PY_VERSIONS=("3.13")

function run_scripts() {
    export MPLBACKEND=Agg
    for s in $(find docs/examples/ch*/solutions/diffpy-cmi/*.py); do
        echo "==========================="
        echo "RUNNING: $s"
        python "$s" > /dev/null || { echo "Script failed: $s"; exit 1; }
    done
}

for PY in "${PY_VERSIONS[@]}"; do
    echo ""
    echo "======== CONDA: Python $PY ========"
    conda create -y -n condatest$PY python=$PY
    source "$(conda info --base)/etc/profile.d/conda.sh"
    conda activate condatest$PY
    conda install -y -c conda-forge diffpy.cmi
    run_scripts || { echo "========== Script failed (conda, $PY) ========="; }
    conda deactivate
    conda env remove -y -n condatest$PY

    echo ""
    echo "======== PIP: Python $PY ========"
    conda create -y -n piptest$PY python=$PY
    source "$(conda info --base)/etc/profile.d/conda.sh"
    conda activate piptest$PY
    pip install diffpy.cmi
    run_scripts || { echo "Script failed (pip, $PY)"; }
    conda deactivate
    conda env remove -y -n piptest$PY
done

echo "Done!"
```