### PR TITLE
simon template for examples testing

### DIFF
--- a/docs/examples/ch03NiModelling/solutions/diffpy-cmi/fitBulkNi.py
+++ b/docs/examples/ch03NiModelling/solutions/diffpy-cmi/fitBulkNi.py
@@ -33,7 +33,7 @@ from diffpy.structure.parsers import getParser
 # First we store the absolute directory of this script,
 # then two directories above this,with the directory
 # 'data' appended
-PWD = Path(__file__).parent.absolute()
+PWD = Path(__file__).parent.resolve()
 DPATH = PWD.parent.parent / "data"
 
 # 3: Give an identifying name for the refinement, similar

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,26 @@
 import json
+
+# tests/conftest.py
+import shutil
 from pathlib import Path
 
 import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+EXAMPLES_ROOT = PROJECT_ROOT / "docs" / "examples"
+
+
+@pytest.fixture(scope="session")
+def tmp_examples(tmp_path_factory):
+    """Copy the entire examples/ tree into a temp directory once per
+    test session.
+
+    Returns the path to that copy.
+    """
+    tmpdir = tmp_path_factory.mktemp("examples")
+    tmp_examples = tmpdir / "examples"
+    shutil.copytree(EXAMPLES_ROOT, tmp_examples)
+    yield tmp_examples
 
 
 @pytest.fixture

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,0 +1,8 @@
+import runpy
+
+
+def test_all_examples(tmp_examples):
+    scripts = list(tmp_examples.rglob("**/solutions/diffpy-cmi/*.py"))
+    for script_path in scripts:
+        print(f"Testing {script_path.relative_to(tmp_examples)}")
+        runpy.run_path(str(script_path), run_name="__main__")


### PR DESCRIPTION
@cadenmyers13 could you make a new PR and try and make a solution that looks more like this to work?  

The basic idea is to copy the entire `docs/examples` directory to the pytest tmdir fixture, then run everything from there.
Please double check that all output files are written to the tmpdir  At least in the NI example they are because they write to `PWD/...` and `PWD` is `Path('__file__').parent`, so as long as we discover the `*.py` file in the tmpdir copy we should be good to go.  Nice aspect is that the code for this is super-simple.

Maybe lets add `psutils` to `requirements/tests.txt` rather than comment it out in the example.   You will have to do the headless thing etc., but I think this could work, something like this. 