### PR TITLE
chore: move function `get_package_dir`into `packsmanager.py`

### DIFF
--- a/news/move-get-packages-dir.rst
+++ b/news/move-get-packages-dir.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* No news added: Move function get_package_dir from __init__.py into packsmanager.py.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/src/diffpy/cmi/__init__.py
+++ b/src/diffpy/cmi/__init__.py
@@ -15,32 +15,9 @@
 """Complex modeling infrastructure:
 a modular framework for multi-modal modeling of scientific data."""
 
-from importlib.resources import as_file, files
-
-
-def get_package_dir(root_path=None):
-    """Get the package directory as a context manager.
-
-    Parameters
-    ----------
-    root_path : str, optional
-        Used for testing, overrides the files(__name__) call.
-
-    Returns
-    -------
-    context manager
-        A context manager that yields a pathlib.Path to the package directory.
-    """
-    if root_path is None:
-        resource = files(__name__)
-    else:
-        resource = root_path
-    return as_file(resource)
-
 
 __all__ = [
     "__version__",
-    "get_package_dir",
 ]
 
 # package version

--- a/src/diffpy/cmi/cli.py
+++ b/src/diffpy/cmi/cli.py
@@ -18,10 +18,10 @@ from pathlib import Path
 from shutil import copytree
 from typing import Dict, List, Optional, Tuple
 
-from diffpy.cmi import __version__, get_package_dir
+from diffpy.cmi import __version__
 from diffpy.cmi.conda import env_info
 from diffpy.cmi.log import plog, set_log_mode
-from diffpy.cmi.packsmanager import PacksManager
+from diffpy.cmi.packsmanager import PacksManager, get_package_dir
 from diffpy.cmi.profilesmanager import ProfilesManager
 
 

--- a/src/diffpy/cmi/packsmanager.py
+++ b/src/diffpy/cmi/packsmanager.py
@@ -13,10 +13,10 @@
 #
 ##############################################################################
 
+from importlib.resources import as_file
 from pathlib import Path
 from typing import List, Union
 
-from diffpy.cmi import get_package_dir
 from diffpy.cmi.installer import (
     ParsedReq,
     install_requirements,
@@ -25,7 +25,27 @@ from diffpy.cmi.installer import (
 )
 from diffpy.cmi.log import plog
 
-__all__ = ["PacksManager"]
+__all__ = ["PacksManager", "get_package_dir"]
+
+
+def get_package_dir(root_path=None):
+    """Get the package directory as a context manager.
+
+    Parameters
+    ----------
+    root_path : str, optional
+        Used for testing, overrides the files(__name__) call.
+
+    Returns
+    -------
+    context manager
+        A context manager that yields a pathlib.Path to the package directory.
+    """
+    if root_path is None:
+        resource = Path(__file__).parents[0]
+    else:
+        resource = root_path
+    return as_file(resource)
 
 
 def _installed_packs_dir(root_path=None) -> Path:


### PR DESCRIPTION
### What problem does this PR address?

Closes #57 

Move `get_package_dir` from `__init__.py` to `packsmanager.py`
